### PR TITLE
Implement inspection type filtering

### DIFF
--- a/Angular13/angular13-inspection-api/src/app/inspection-api.service.ts
+++ b/Angular13/angular13-inspection-api/src/app/inspection-api.service.ts
@@ -16,6 +16,14 @@ export class InspectionApiService {
     return this.http.get<any>(this.inspectionAPIUrl + '/Inspections');
   }
 
+  filterInspectionsByType(typeId:number|string|null):Observable<any[]> {
+    let params = '';
+    if(typeId !== null && typeId !== '') {
+      params = `?inspectionTypeId=${typeId}`;
+    }
+    return this.http.get<any>(this.inspectionAPIUrl + `/Inspections/filterByType${params}`);
+  }
+
   addInspection(data:any) {
     return this.http.post(this.inspectionAPIUrl + '/Inspections', data)
   }

--- a/Angular13/angular13-inspection-api/src/app/inspection/show-inspection/show-inspection.component.html
+++ b/Angular13/angular13-inspection-api/src/app/inspection/show-inspection/show-inspection.component.html
@@ -15,6 +15,14 @@
   Show Status
 </button>
 
+<div class="mb-2">
+  <label for="typeFilter" class="form-label me-2">Inspection Type:</label>
+  <select id="typeFilter" class="form-select d-inline-block w-auto" (change)="filterByType($event.target.value)">
+    <option value="">All Types</option>
+    <option *ngFor="let type of inspectionTypesList$|async" [value]="type.id">{{type.inspectionName}}</option>
+  </select>
+</div>
+
 <table class="table table-striped">
   <thead>
     <th>Id</th>

--- a/Angular13/angular13-inspection-api/src/app/inspection/show-inspection/show-inspection.component.ts
+++ b/Angular13/angular13-inspection-api/src/app/inspection/show-inspection/show-inspection.component.ts
@@ -14,6 +14,8 @@ export class ShowInspectionComponent implements OnInit {
   statusList$!: Observable<any[]>;
   inspectionTypesList:any=[];
 
+  selectedTypeId:string = '';
+
   // Map to display data associate with foreign keys
   inspectionTypesMap:Map<number, string> = new Map()
 
@@ -21,7 +23,6 @@ export class ShowInspectionComponent implements OnInit {
 
   ngOnInit(): void {
 
-    this.inspectionList$ = this.service.getInspectionList();
     this.inspectionTypesList$ = this.service.getInspectionTypesList();
     this.statusList$ = this.service.getStatusList();
     this.refreshInspectionTypesMap();
@@ -45,6 +46,9 @@ export class ShowInspectionComponent implements OnInit {
     if(showdeleteError) {
       showdeleteError.style.display = "none";
     }
+
+    // initial load of inspections
+    this.filterByType('');
   }
 
   // Variables (properties)
@@ -76,7 +80,7 @@ export class ShowInspectionComponent implements OnInit {
 
   modalClose() {
     this.activateAddEditInspectionComponent = false;
-    this.inspectionList$ = this.service.getInspectionList();
+    this.filterByType(this.selectedTypeId);
   }
 
   modalAddStatus() {
@@ -193,10 +197,16 @@ export class ShowInspectionComponent implements OnInit {
 
       for(let i = 0; i < data.length; i++)
       {
-        this.inspectionTypesMap.set(this.inspectionTypesList[i].id, 
-          this.inspectionTypesList[i].inspectionName);
+      this.inspectionTypesMap.set(this.inspectionTypesList[i].id,
+        this.inspectionTypesList[i].inspectionName);
       }
     })
   }
+
+  filterByType(typeId:string) {
+    this.selectedTypeId = typeId;
+    this.inspectionList$ = this.service.filterInspectionsByType(typeId);
+  }
+
 
 }

--- a/InspectionApiApp/InspectionApiApp/Controllers/InspectionsController.cs
+++ b/InspectionApiApp/InspectionApiApp/Controllers/InspectionsController.cs
@@ -43,6 +43,20 @@ namespace InspectionApiApp.Controllers
             return inspection;
         }
 
+        // GET: api/Inspections/filterByType?inspectionTypeId=1
+        [HttpGet("filterByType")]
+        public async Task<ActionResult<IEnumerable<Inspection>>> FilterByType([FromQuery] int? inspectionTypeId)
+        {
+            var query = _context.Inspections.AsQueryable();
+
+            if (inspectionTypeId.HasValue)
+            {
+                query = query.Where(i => i.InspectionTypeId == inspectionTypeId.Value);
+            }
+
+            return await query.ToListAsync();
+        }
+
         // PUT: api/Inspections/5
         // To protect from overposting attacks, see https://go.microsoft.com/fwlink/?linkid=2123754
         [HttpPut("{id}")]


### PR DESCRIPTION
## Summary
- add backend endpoint to filter inspections by type
- expose filter method in frontend service
- add dropdown on inspection list for type filtering
- refresh view on inspection changes

## Testing
- `dotnet test --no-build` *(fails: command not found)*
- `npm test --silent` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_68531e3c3d2083289260602256d12a5e